### PR TITLE
TruckSim: Fixed GitHub URL not opening in settings window

### DIFF
--- a/Module.TruckSimulator/ViewModels/TruckSimulatorConfigurationViewModel.cs
+++ b/Module.TruckSimulator/ViewModels/TruckSimulatorConfigurationViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using Artemis.Core;
 using Microsoft.Win32;
-using System.Diagnostics;
 using System.IO;
+using System.Windows.Navigation;
 
 namespace Artemis.Plugins.Modules.TruckSimulator.ViewModels {
     public class TruckSimulatorConfigurationViewModel : PluginConfigurationViewModel {
@@ -68,8 +68,8 @@ namespace Artemis.Plugins.Modules.TruckSimulator.ViewModels {
             return dialog.ShowDialog() == true ? Path.GetDirectoryName(Path.GetDirectoryName(dialog.FileName)) : null;
         }
 
-        public void OpenPluginGithub() {
-            Process.Start(new ProcessStartInfo("cmd", $"/c start https://github.com/RenCloud/scs-sdk-plugin") { CreateNoWindow = true });
+        public void OpenHyperlink(object sender, RequestNavigateEventArgs e) {
+            Utilities.OpenUrl(e.Uri.AbsoluteUri);
         }
     }
 }

--- a/Module.TruckSimulator/Views/TruckSimulatorConfigurationView.xaml
+++ b/Module.TruckSimulator/Views/TruckSimulatorConfigurationView.xaml
@@ -26,7 +26,9 @@
 
         <TextBlock TextWrapping="Wrap">
             <Run>The source for this ETS2/ATS plugin can be found at</Run>
-            <Hyperlink RequestNavigate="{s:Action OpenPluginGithub}">https://github.com/RenCloud/scs-sdk-plugin</Hyperlink>
+            <Hyperlink RequestNavigate="{s:Action OpenHyperlink}" NavigateUri="https://github.com/RenCloud/scs-sdk-plugin">
+                https://github.com/RenCloud/scs-sdk-plugin
+            </Hyperlink>
             <Run>.</Run>
         </TextBlock>
     </StackPanel>


### PR DESCRIPTION
Updated to use the new utility from https://github.com/Artemis-RGB/Artemis/pull/484

Also it turns out `RequestNavigate` never triggers if a `NavigateUri` is not provided.
To keep the actual URL a view concern, I updated the method to simply use the event argument, hope you don't mind.